### PR TITLE
fix: remove interaction pages from main sitemap to fix Vercel build t…

### DIFF
--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -45,11 +45,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ]
 
   try {
-    const [slugRes, classRes, guideSlugRes, interactionSlugRes] = await Promise.all([
+    const [slugRes, classRes, guideSlugRes] = await Promise.all([
       fetch(`${API_BASE}/api/slugs`, { next: { revalidate: 86400 } }),
       fetch(`${API_BASE}/api/classes`, { next: { revalidate: 86400 } }),
       fetch(`${API_BASE}/api/slugs/guide-pages`, { next: { revalidate: 86400 } }),
-      fetch(`${API_BASE}/api/slugs/interactions`, { next: { revalidate: 86400 } }),
     ])
 
     if (!slugRes.ok) {
@@ -68,18 +67,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       has_dosage?: boolean
       has_adverse_reactions?: boolean
     }
-    type InteractionSlugEntry = {
-      slug: string
-      drug_name: string
-      has_drug_interactions: boolean
-      has_food_interactions: boolean
-      has_disease_interactions: boolean
-    }
     const guideSlugs: GuideSlugEntry[] = guideSlugRes.ok
       ? await guideSlugRes.json()
-      : []
-    const interactionSlugs: InteractionSlugEntry[] = interactionSlugRes.ok
-      ? await interactionSlugRes.json()
       : []
 
     let classes: Array<{ slug: string }> = []
@@ -144,13 +133,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         priority: 0.7,
       }))
 
-    const interactionPages: MetadataRoute.Sitemap = interactionSlugs
-      .filter((entry) => entry.slug)
-      .map((entry) => ({
-        url: `${SITE_URL}/pill/${encodeURIComponent(entry.slug)}/interactions`,
-        changeFrequency: 'monthly' as const,
-        priority: 0.7,
-      }))
+    // NOTE: Interaction pages are served via the dedicated /sitemap-interactions.xml
+    // route (see frontend/app/sitemap-interactions.xml/route.ts) to avoid pushing
+    // the main sitemap past Vercel's 60-second build timeout and 2MB cache limit.
 
     return [
       ...staticPages,
@@ -160,7 +145,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       ...medicationSummaryPages,
       ...dosagePages,
       ...adverseReactionsPages,
-      ...interactionPages,
       ...classPages,
     ]
   } catch (err) {


### PR DESCRIPTION
…imeout

The main sitemap.ts was fetching /api/slugs/interactions on top of the existing 3 large API calls, pushing the build past Vercel's 60-second timeout and 2MB data cache limit. Interaction pages already have their own dedicated /sitemap-interactions.xml route, so including them in the main sitemap was redundant. Removing them fixes the build.