### PR TITLE
Remove semrushbot and ahrefsbot from middleware

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -12,8 +12,6 @@ const BAD_BOTS = [
   'axios',
   'java/',
   'petalbot',
-  'semrushbot',
-  'ahrefsbot',
   'mj12bot',
   'dotbot',
   'blexbot',


### PR DESCRIPTION
Removed 'semrushbot' and 'ahrefsbot' from the middleware bot list.